### PR TITLE
Fix commas in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,8 @@ if (program.opts().block2) {
 
 if (typeof program.opts().coapOption !== 'undefined' && program.opts().coapOption.length > 0) {
   program.opts().coapOption.forEach(function (singleOption) {
-    const kvPair = singleOption.split(coapOptionSeperator, 2)
+    const i = singleOption.indexOf(coapOptionSeperator)
+    const kvPair = [singleOption.slice(0, i), singleOption.slice(i + 1)]
     const optionValueBuffer = kvPair[1].startsWith('0x') ? Buffer.from(kvPair[1].substr(2), 'hex') : Buffer.from(kvPair[1])
     req.setOption(kvPair[0], optionValueBuffer)
   })

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ if (typeof program.opts().coapOption !== 'undefined' && program.opts().coapOptio
   program.opts().coapOption.forEach(function (singleOption) {
     const i = singleOption.indexOf(coapOptionSeperator)
     const kvPair = [singleOption.slice(0, i), singleOption.slice(i + 1)]
-    const optionValueBuffer = kvPair[1].startsWith('0x') ? Buffer.from(kvPair[1].substr(2), 'hex') : Buffer.from(kvPair[1])
+    const optionValueBuffer = kvPair[1].startsWith('0x') ? Buffer.from(kvPair[1].substring(2), 'hex') : Buffer.from(kvPair[1])
     req.setOption(kvPair[0], optionValueBuffer)
   })
 }

--- a/test.js
+++ b/test.js
@@ -324,4 +324,20 @@ describe('coap', function () {
       }
     })
   })
+
+  it('should support coap option as string that contains commas', function (done) {
+    call('get', '-O 15,sharedKeys=foo,bar,baz', 'coap://localhost')
+
+    server.once('request', function (req, res) {
+      res.end('')
+      try {
+        expect(req._packet.options.length).to.eql(1)
+        expect(req._packet.options[0].name).to.eql('Uri-Query')
+        expect(req._packet.options[0].value.toString()).to.eql('sharedKeys=foo,bar,baz')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  })
 })


### PR DESCRIPTION
Currently the CLI arguments for options are split at commas which makes it impossible to give option values which actually contain commas. Unfortunately this is a pretty common use-case for "Uri-Query" options.

This fix splits the CLI arguments only at the first comma to separate the option number from the payload, but keeps everything that follows as-is, without cutting the value off at the next comma it might contain.

This also fixes a warning because of the deprecated `substr`.